### PR TITLE
Check in parent_dirs for pyproject.toml

### DIFF
--- a/data_kernelspec/kernel.json
+++ b/data_kernelspec/kernel.json
@@ -1,1 +1,0 @@
-{"argv": ["python", "-m", "poetry_kernel", "-f", "{connection_file}"], "display_name": "Poetry", "language": "python"}

--- a/data_kernelspec/kernel.json
+++ b/data_kernelspec/kernel.json
@@ -1,0 +1,1 @@
+{"argv": ["python", "-m", "poetry_kernel", "-f", "{connection_file}"], "display_name": "Poetry", "language": "python"}

--- a/poetry_kernel/__main__.py
+++ b/poetry_kernel/__main__.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import os.path
 import signal
 import subprocess
@@ -5,11 +6,16 @@ import sys
 
 import colorama
 
-
 def main():
+    candidates = [Path().resolve()]
+    candidates.extend(Path().resolve().parents)
     colorama.init()
 
-    if not os.path.exists("pyproject.toml"):
+    for dirs in candidates:
+        poetry_file = dirs / "pyproject.toml"
+        if poetry_file.exists():
+            break
+    else:
         print(
             colorama.Fore.RED + colorama.Style.BRIGHT +
             "\n" +
@@ -22,7 +28,7 @@ def main():
             sep="\n",
         )
         raise RuntimeError("Cannot start Poetry kernel: expected pyproject.toml")
-
+ 
     cmd = [
         "poetry", "run",
         "python", "-m", "ipykernel_launcher",


### PR DESCRIPTION
This now loops through parent directories to check for pyproject.toml to allow for kernel execution when running notebooks in sub directories. I used the same code from poetry itself to ensure compatibility