### PR TITLE
modified forward_signals to be compatible with windows

### DIFF
--- a/poetry_kernel/__main__.py
+++ b/poetry_kernel/__main__.py
@@ -1,8 +1,8 @@
-from pathlib import Path
-import os.path
+import platform
 import signal
 import subprocess
 import sys
+from pathlib import Path
 
 import colorama
 
@@ -36,7 +36,10 @@ def main():
     ]
     proc = subprocess.Popen(cmd)
 
-    forward_signals = set(signal.Signals) - {signal.SIGKILL, signal.SIGSTOP}
+    if platform.system() == 'Windows':
+        forward_signals = set(signal.Signals) - {signal.CTRL_BREAK_EVENT, signal.CTRL_C_EVENT, signal.SIGTERM}
+    else:
+        forward_signals = set(signal.Signals) - {signal.SIGKILL, signal.SIGSTOP}
 
     def handle_signal(sig, _frame):
         proc.send_signal(sig)


### PR DESCRIPTION
in regard to issue #3

removed signal.SIGTERM from forward_signals, as well as two others as they could not be used by signal.signal (ValueError: invalid signal value)

from https://docs.python.org/3/library/signal.html
signal.CTRL_C_EVENT
The signal corresponding to the Ctrl+C keystroke event. This signal can only be used with os.kill()

same for signal.CTRL_BREAK_EVENT